### PR TITLE
Cw1155 Approve/Revoke single

### DIFF
--- a/contracts/cw1155-base/src/lib.rs
+++ b/contracts/cw1155-base/src/lib.rs
@@ -9,6 +9,9 @@ pub use crate::state::Cw1155Contract;
 use cosmwasm_std::Empty;
 use cw1155::Cw1155QueryMsg;
 
+// todo - is this standard?
+pub const CW_ADDRESS_LENGTH: usize = 62;
+
 // This is a simple type to let us handle empty extensions
 pub type Extension = Option<Empty>;
 

--- a/contracts/cw1155-base/src/msg.rs
+++ b/contracts/cw1155-base/src/msg.rs
@@ -40,14 +40,9 @@ pub enum ExecuteMsg<T> {
         msg: Option<Binary>,
     },
     /// Burn is a base message to burn tokens.
-    Burn {
-        token_id: String,
-        amount: Uint128,
-    },
+    Burn { token_id: String, amount: Uint128 },
     /// BatchBurn is a base message to burn multiple types of tokens in batch.
-    BatchBurn {
-        batch: Vec<TokenAmount>,
-    },
+    BatchBurn { batch: Vec<TokenAmount> },
     /// Allows operator to transfer / send any token from the owner's account.
     /// If expiration is set, then this allowance has a time/height limit
     ApproveAll {

--- a/contracts/cw1155-base/src/msg.rs
+++ b/contracts/cw1155-base/src/msg.rs
@@ -43,6 +43,22 @@ pub enum ExecuteMsg<T> {
     Burn { token_id: String, amount: Uint128 },
     /// BatchBurn is a base message to burn multiple types of tokens in batch.
     BatchBurn { batch: Vec<TokenAmount> },
+    /// Allows operator to transfer / send the token from the owner's account.
+    /// If expiration is set, then this allowance has a time/height limit
+    Approve {
+        spender: String,
+        token_id: String,
+        /// Optional amount to approve. If None, approve entire balance.
+        amount: Option<Uint128>,
+        expires: Option<Expiration>,
+    },
+    /// Remove previously granted Approval
+    Revoke {
+        spender: String,
+        token_id: String,
+        /// Optional amount to revoke. If None, revoke entire amount.
+        amount: Option<Uint128>,
+    },
     /// Allows operator to transfer / send any token from the owner's account.
     /// If expiration is set, then this allowance has a time/height limit
     ApproveAll {

--- a/contracts/cw1155-base/src/query.rs
+++ b/contracts/cw1155-base/src/query.rs
@@ -11,7 +11,7 @@ use cw1155::{
 use cw_storage_plus::Bound;
 use cw_utils::maybe_addr;
 
-use crate::state::{Cw1155Contract, TokenKey};
+use crate::state::Cw1155Contract;
 
 const DEFAULT_LIMIT: u32 = 10;
 const MAX_LIMIT: u32 = 100;
@@ -72,11 +72,10 @@ where
                 token_id,
                 include_expired,
             } => {
-                let token_key = TokenKey::new(&env, &token_id);
                 let owner = deps.api.addr_validate(&owner)?;
                 let approvals = self
                     .token_approves
-                    .prefix((&token_key, &owner))
+                    .prefix((&token_id, &owner))
                     .range(deps.storage, None, None, Order::Ascending)
                     .filter_map(|approval| {
                         let (_, approval) = approval.unwrap();

--- a/contracts/cw1155-base/src/state.rs
+++ b/contracts/cw1155-base/src/state.rs
@@ -130,6 +130,12 @@ pub struct TokenApproval {
     pub expiration: Expiration,
 }
 
+impl TokenApproval {
+    pub fn is_expired(&self, env: &Env) -> bool {
+        self.expiration.is_expired(&env.block)
+    }
+}
+
 #[cw_serde]
 pub struct TokenKey {
     pub address: Addr,

--- a/contracts/cw1155-base/src/state.rs
+++ b/contracts/cw1155-base/src/state.rs
@@ -1,59 +1,76 @@
+use cosmwasm_schema::cw_serde;
 use schemars::JsonSchema;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
-use cosmwasm_std::{Addr, StdResult, Storage, Uint128};
+use cosmwasm_std::{Addr, Env, StdResult, Storage, Uint128};
 
+use crate::CW_ADDRESS_LENGTH;
 use cw1155::{Balance, Expiration};
-use cw_storage_plus::{Index, IndexList, IndexedMap, Item, Map, MultiIndex};
+use cw_storage_plus::{
+    Index, IndexList, IndexedMap, Item, Key, KeyDeserialize, Map, MultiIndex, Prefixer, PrimaryKey,
+};
 
 pub struct Cw1155Contract<'a, T>
-    where
-        T: Serialize + DeserializeOwned + Clone,
+where
+    T: Serialize + DeserializeOwned + Clone,
 {
     pub minter: Item<'a, Addr>,
+    // key: token id
     pub token_count: Map<'a, &'a str, Uint128>,
+    // key: (owner, token id)
     pub balances: IndexedMap<'a, (Addr, String), Balance, BalanceIndexes<'a>>,
+    // key: (owner, spender)
     pub approves: Map<'a, (&'a Addr, &'a Addr), Expiration>,
+    // key: (token key, owner, spender)
+    pub token_approves: Map<'a, (&'a TokenKey, &'a Addr, &'a Addr), TokenApproval>,
+    // key: token id
     pub tokens: Map<'a, &'a str, TokenInfo<T>>,
 }
 
 impl<'a, T> Default for Cw1155Contract<'static, T>
-    where
-        T: Serialize + DeserializeOwned + Clone,
+where
+    T: Serialize + DeserializeOwned + Clone,
 {
     fn default() -> Self {
         Self::new(
             "minter",
+            "tokens",
             "token_count",
             "balances",
-            "approves",
-            "tokens",
             "balances__token_id",
+            "approves",
+            "token_approves",
         )
     }
 }
 
 impl<'a, T> Cw1155Contract<'a, T>
-    where
-        T: Serialize + DeserializeOwned + Clone,
+where
+    T: Serialize + DeserializeOwned + Clone,
 {
     fn new(
         minter_key: &'a str,
+        tokens_key: &'a str,
         token_count_key: &'a str,
         balances_key: &'a str,
-        approves_key: &'a str,
-        tokens_key: &'a str,
         balances_token_id_key: &'a str,
+        approves_key: &'a str,
+        token_approves_key: &'a str,
     ) -> Self {
-        let indexes = BalanceIndexes {
-            token_id: MultiIndex::new(|_, b| b.token_id.to_string(), balances_key, balances_token_id_key),
+        let balances_indexes = BalanceIndexes {
+            token_id: MultiIndex::new(
+                |_, b| b.token_id.to_string(),
+                balances_key,
+                balances_token_id_key,
+            ),
         };
         Self {
             minter: Item::new(minter_key),
             token_count: Map::new(token_count_key),
-            balances: IndexedMap::new(balances_key, indexes),
+            balances: IndexedMap::new(balances_key, balances_indexes),
             approves: Map::new(approves_key),
+            token_approves: Map::new(token_approves_key),
             tokens: Map::new(tokens_key),
         }
     }
@@ -101,8 +118,61 @@ pub struct BalanceIndexes<'a> {
 }
 
 impl<'a> IndexList<Balance> for BalanceIndexes<'a> {
-    fn get_indexes(&'_ self) -> Box<dyn Iterator<Item=&'_ dyn Index<Balance>> + '_> {
+    fn get_indexes(&'_ self) -> Box<dyn Iterator<Item = &'_ dyn Index<Balance>> + '_> {
         let v: Vec<&dyn Index<Balance>> = vec![&self.token_id];
         Box::new(v.into_iter())
+    }
+}
+
+#[cw_serde]
+pub struct TokenApproval {
+    pub amount: Uint128,
+    pub expiration: Expiration,
+}
+
+#[cw_serde]
+pub struct TokenKey {
+    pub address: Addr,
+    pub token_id: String,
+}
+
+impl TokenKey {
+    pub fn new(env: &Env, token_id: &str) -> Self {
+        Self {
+            address: env.contract.address.clone(),
+            token_id: token_id.to_string(),
+        }
+    }
+}
+
+impl PrimaryKey<'_> for TokenKey {
+    type Prefix = Addr;
+    type SubPrefix = ();
+    type Suffix = String;
+    type SuperSuffix = (Addr, String);
+
+    fn key(&self) -> Vec<Key> {
+        let mut keys = self.address.key();
+        keys.extend(self.token_id.key());
+        keys
+    }
+}
+
+impl Prefixer<'_> for TokenKey {
+    fn prefix(&self) -> Vec<Key> {
+        self.key()
+    }
+}
+
+impl KeyDeserialize for TokenKey {
+    type Output = TokenKey;
+
+    fn from_vec(mut value: Vec<u8>) -> StdResult<Self::Output> {
+        let mut value = value.split_off(2); // remove padding
+        let token_id = value.split_off(CW_ADDRESS_LENGTH);
+        Ok(TokenKey {
+            address: Addr::from_vec(value)?,
+            token_id: String::from_vec(token_id)?,
+        })
     }
 }

--- a/packages/cw1155/src/event.rs
+++ b/packages/cw1155/src/event.rs
@@ -1,6 +1,5 @@
-use cosmwasm_std::{Addr, attr, Event};
 use crate::TokenAmount;
-
+use cosmwasm_std::{attr, Addr, Event, Uint128};
 
 /// Tracks token transfer actions
 pub struct TransferEvent {
@@ -21,13 +20,19 @@ impl TransferEvent {
 
 impl From<TransferEvent> for Event {
     fn from(event: TransferEvent) -> Self {
-        Event::new("transfer_tokens").add_attributes(
-            vec![
-                attr("sender", event.sender.as_str()),
-                attr("recipient", event.recipient.as_str()),
-                attr("tokens", event.tokens.iter().map(|t| t.to_string()).collect::<Vec<_>>().join(",")),
-            ]
-        )
+        Event::new("transfer_tokens").add_attributes(vec![
+            attr("sender", event.sender.as_str()),
+            attr("recipient", event.recipient.as_str()),
+            attr(
+                "tokens",
+                event
+                    .tokens
+                    .iter()
+                    .map(|t| t.to_string())
+                    .collect::<Vec<_>>()
+                    .join(","),
+            ),
+        ])
     }
 }
 
@@ -48,12 +53,18 @@ impl MintEvent {
 
 impl From<MintEvent> for Event {
     fn from(event: MintEvent) -> Self {
-        Event::new("mint_tokens").add_attributes(
-            vec![
-                attr("recipient", event.recipient.as_str()),
-                attr("tokens", event.tokens.iter().map(|t| t.to_string()).collect::<Vec<_>>().join(",")),
-            ]
-        )
+        Event::new("mint_tokens").add_attributes(vec![
+            attr("recipient", event.recipient.as_str()),
+            attr(
+                "tokens",
+                event
+                    .tokens
+                    .iter()
+                    .map(|t| t.to_string())
+                    .collect::<Vec<_>>()
+                    .join(","),
+            ),
+        ])
     }
 }
 
@@ -74,12 +85,78 @@ impl BurnEvent {
 
 impl From<BurnEvent> for Event {
     fn from(event: BurnEvent) -> Self {
-        Event::new("burn_tokens").add_attributes(
-            vec![
-                attr("sender", event.sender.as_str()),
-                attr("tokens", event.tokens.iter().map(|t| t.to_string()).collect::<Vec<_>>().join(",")),
-            ]
-        )
+        Event::new("burn_tokens").add_attributes(vec![
+            attr("sender", event.sender.as_str()),
+            attr(
+                "tokens",
+                event
+                    .tokens
+                    .iter()
+                    .map(|t| t.to_string())
+                    .collect::<Vec<_>>()
+                    .join(","),
+            ),
+        ])
+    }
+}
+
+/// Tracks approve status changes
+pub struct ApproveEvent {
+    pub sender: Addr,
+    pub operator: Addr,
+    pub token_id: String,
+    pub amount: Uint128,
+}
+
+impl ApproveEvent {
+    pub fn new(sender: &Addr, operator: &Addr, token_id: &str, amount: Uint128) -> Self {
+        Self {
+            sender: sender.clone(),
+            operator: operator.clone(),
+            token_id: token_id.to_string(),
+            amount,
+        }
+    }
+}
+
+impl From<ApproveEvent> for Event {
+    fn from(event: ApproveEvent) -> Self {
+        Event::new("approve_single").add_attributes(vec![
+            attr("sender", event.sender.as_str()),
+            attr("operator", event.operator.as_str()),
+            attr("token_id", event.token_id),
+            attr("amount", event.amount.to_string()),
+        ])
+    }
+}
+
+/// Tracks revoke status changes
+pub struct RevokeEvent {
+    pub sender: Addr,
+    pub operator: Addr,
+    pub token_id: String,
+    pub amount: Uint128,
+}
+
+impl RevokeEvent {
+    pub fn new(sender: &Addr, operator: &Addr, token_id: &str, amount: Uint128) -> Self {
+        Self {
+            sender: sender.clone(),
+            operator: operator.clone(),
+            token_id: token_id.to_string(),
+            amount,
+        }
+    }
+}
+
+impl From<RevokeEvent> for Event {
+    fn from(event: RevokeEvent) -> Self {
+        Event::new("revoke_single").add_attributes(vec![
+            attr("sender", event.sender.as_str()),
+            attr("operator", event.operator.as_str()),
+            attr("token_id", event.token_id),
+            attr("amount", event.amount.to_string()),
+        ])
     }
 }
 
@@ -100,12 +177,10 @@ impl ApproveAllEvent {
 
 impl From<ApproveAllEvent> for Event {
     fn from(event: ApproveAllEvent) -> Self {
-        Event::new("approve_all").add_attributes(
-            vec![
-                attr("sender", event.sender.as_str()),
-                attr("operator", event.operator.as_str()),
-            ]
-        )
+        Event::new("approve_all").add_attributes(vec![
+            attr("sender", event.sender.as_str()),
+            attr("operator", event.operator.as_str()),
+        ])
     }
 }
 
@@ -126,11 +201,9 @@ impl RevokeAllEvent {
 
 impl From<RevokeAllEvent> for Event {
     fn from(event: RevokeAllEvent) -> Self {
-        Event::new("revoke_all").add_attributes(
-            vec![
-                attr("sender", event.sender.as_str()),
-                attr("operator", event.operator.as_str()),
-            ]
-        )
+        Event::new("revoke_all").add_attributes(vec![
+            attr("sender", event.sender.as_str()),
+            attr("operator", event.operator.as_str()),
+        ])
     }
 }

--- a/packages/cw1155/src/msg.rs
+++ b/packages/cw1155/src/msg.rs
@@ -1,7 +1,7 @@
-use std::fmt::{Display, Formatter};
 use cosmwasm_schema::cw_serde;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use std::fmt::{Display, Formatter};
 
 use cosmwasm_std::{Binary, Uint128};
 use cw_utils::Expiration;

--- a/packages/cw1155/src/query.rs
+++ b/packages/cw1155/src/query.rs
@@ -28,6 +28,12 @@ pub enum Cw1155QueryMsg {
     },
     /// Total number of tokens issued for the token id
     NumTokens { token_id: String },
+    /// Return approvals that a token owner has
+    Approvals {
+        owner: String,
+        token_id: String,
+        include_expired: Option<bool>,
+    },
     /// List all operators that can access all of the owner's tokens.
     /// Return type: ApprovedForAllResponse.
     ApprovedForAll {


### PR DESCRIPTION
This implements a `token_approves` Map in order to store approvals on specific tokens/amounts that a user owns. It is expected to work the same as approvals on cw721 but with an amount argument to limit the quantity of the token the operator has access to.